### PR TITLE
Fix MedidaItem usage and update widget test

### DIFF
--- a/lib/features/preparacao/data/api_client.dart
+++ b/lib/features/preparacao/data/api_client.dart
@@ -13,6 +13,6 @@ class ApiMedidasRepository implements MedidasRepository {
       'op': operacao.trim(),
     });
     final list = (resp.data['medidas'] as List).cast<Map<String, dynamic>>();
-    return list.map(MedidaItem.fromJson).toList();
+    return list.map((e) => MedidaItem.fromMap(e)).toList();
   }
 }

--- a/lib/features/preparacao/data/local_excel_repository.dart
+++ b/lib/features/preparacao/data/local_excel_repository.dart
@@ -32,7 +32,12 @@ class LocalExcelRepository implements MedidasRepository {
           if (ambosVazios) break; // chegou ao fim
 
           if (etiqueta.isNotEmpty || especificacao.isNotEmpty) {
-            medidas.add(MedidaItem(etiqueta: etiqueta, especificacao: especificacao));
+            medidas.add(
+              MedidaItem(
+                titulo: etiqueta,
+                faixaTexto: especificacao,
+              ),
+            );
           }
           col += 2; // próximo par (I/J, K/L, ...)
         }

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -89,7 +89,7 @@ class PreparacaoFiltro {
     required this.operacao,
   });
 
-  String get chaveCadastro => '${partnumber}*${operacao}';
+  String get chaveCadastro => '$partnumber*$operacao';
 }
 
 class ResultadoItem {

--- a/lib/features/preparacao/presentation/widgets/measurement_tile.dart
+++ b/lib/features/preparacao/presentation/widgets/measurement_tile.dart
@@ -18,9 +18,9 @@ class MeasurementTile extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(item.etiqueta.isEmpty ? '(sem etiqueta)' : item.etiqueta, style: styleLabel),
+            Text(item.titulo.isEmpty ? '(sem etiqueta)' : item.titulo, style: styleLabel),
             const SizedBox(height: 4),
-            Text(item.especificacao.isEmpty ? '(sem especificação)' : item.especificacao, style: styleSpec),
+            Text(item.faixaTexto.isEmpty ? '(sem especificação)' : item.faixaTexto, style: styleSpec),
             const SizedBox(height: 8),
             Wrap(
               spacing: 8,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,25 +6,17 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:relic_ttprod/main.dart';
+import 'package:relic_ttprod/app.dart';
+import 'package:relic_ttprod/features/preparacao/presentation/widgets/preparacao_page.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('App builds home page', (WidgetTester tester) async {
+    await tester.pumpWidget(const ProviderScope(child: App()));
+    expect(find.byType(PreparacaoPage), findsOneWidget);
+    // Check that the expected title is shown
+    expect(find.text('Preparação de OS'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- parse API responses with `MedidaItem.fromMap`
- align Excel repository and UI with `MedidaItem` fields
- modernize widget test to build `App`

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a35b5d3fac8331a8abdeb416723f37