### PR TITLE
Add main menu and operator area

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'features/preparacao/presentation/widgets/preparacao_page.dart';
+import 'features/main_menu/main_menu_page.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -9,7 +9,7 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: 'Relic TT Prod',
       debugShowCheckedModeBanner: false,
-      home: const PreparacaoPage(), // <- aqui tá a sua home
+      home: const MainMenuPage(), // Menu principal com áreas
     );
   }
 }

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import '../preparacao/presentation/widgets/preparacao_page.dart';
+import '../operador/presentation/operador_page.dart';
+
+class MainMenuPage extends StatelessWidget {
+  const MainMenuPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Menu Principal')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const PreparacaoPage(),
+                  ),
+                );
+              },
+              child: const Text('Área do Preparador'),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const OperadorPage(),
+                  ),
+                );
+              },
+              child: const Text('Área do Operador'),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const _SupervisaoPage(),
+                  ),
+                );
+              },
+              child: const Text('Supervisão'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SupervisaoPage extends StatelessWidget {
+  const _SupervisaoPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(title: Text('Supervisão')),
+      body: Center(child: Text('Em desenvolvimento')),
+    );
+  }
+}

--- a/lib/features/operador/data/repository_provider.dart
+++ b/lib/features/operador/data/repository_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../preparacao/data/medidas_repository.dart';
+import '../../preparacao/data/api_medidas_repository.dart';
+
+final operadorRepositoryProvider = Provider<MedidasRepository>((ref) {
+  return ApiMedidasRepository(
+    medidasPath: '/operador/medidas',
+    resultadoPath: '/operador/resultado',
+  );
+});

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -1,0 +1,272 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../preparacao/data/models.dart';
+import '../data/repository_provider.dart';
+
+final medidasOperadorControllerProvider = StateNotifierProvider.autoDispose<
+    MedidasOperadorController, AsyncValue<List<MedidaItem>>>((ref) {
+  return MedidasOperadorController(ref);
+});
+
+class MedidasOperadorController
+    extends StateNotifier<AsyncValue<List<MedidaItem>>> {
+  final Ref _ref;
+  MedidasOperadorController(this._ref) : super(const AsyncValue.data([]));
+
+  Future<void> carregar({
+    required String partnumber,
+    required String operacao,
+  }) async {
+    state = const AsyncValue.loading();
+    try {
+      final repo = _ref.read(operadorRepositoryProvider);
+      final itens =
+          await repo.getMedidas(partnumber: partnumber, operacao: operacao);
+      state = AsyncValue.data(itens);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  void setStatus(int index, StatusMedida status) {
+    final current = [...(state.value ?? const <MedidaItem>[])];
+    if (index < 0 || index >= current.length) return;
+    current[index] = MedidaItem(
+      titulo: current[index].titulo,
+      faixaTexto: current[index].faixaTexto,
+      minimo: current[index].minimo,
+      maximo: current[index].maximo,
+      unidade: current[index].unidade,
+      status: status,
+      observacao: current[index].observacao,
+    );
+    state = AsyncValue.data(current);
+  }
+}
+
+class OperadorPage extends ConsumerStatefulWidget {
+  const OperadorPage({super.key});
+
+  @override
+  ConsumerState<OperadorPage> createState() => _OperadorPageState();
+}
+
+class _OperadorPageState extends ConsumerState<OperadorPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _reCtrl = TextEditingController();
+  final _partCtrl = TextEditingController();
+  final _opCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _reCtrl.dispose();
+    _partCtrl.dispose();
+    _opCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final medidasAsync = ref.watch(medidasOperadorControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Área do Operador'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 12.0),
+            child: Center(
+              child: Text(
+                Platform.isWindows
+                    ? 'Windows: leitura direta/API'
+                    : 'Android: via API',
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+          )
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      controller: _reCtrl,
+                      decoration: const InputDecoration(
+                        labelText: 'RE do Operador',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (v) =>
+                          (v == null || v.trim().isEmpty) ? 'Obrigatório' : null,
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: _partCtrl,
+                            decoration: const InputDecoration(
+                              labelText: 'Código da peça (PartNumber)',
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (v) =>
+                                (v == null || v.trim().isEmpty)
+                                    ? 'Obrigatório'
+                                    : null,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        SizedBox(
+                          width: 140,
+                          child: TextFormField(
+                            controller: _opCtrl,
+                            decoration: const InputDecoration(
+                              labelText: 'Operação',
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (v) =>
+                                (v == null || v.trim().isEmpty)
+                                    ? 'Obrigatório'
+                                    : null,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        onPressed: () async {
+                          if (_formKey.currentState!.validate()) {
+                            FocusScope.of(context).unfocus();
+                            await ref
+                                .read(
+                                    medidasOperadorControllerProvider.notifier)
+                                .carregar(
+                                  partnumber: _partCtrl.text.trim(),
+                                  operacao: _opCtrl.text.trim(),
+                                );
+                          }
+                        },
+                        icon: const Icon(Icons.search),
+                        label: const Text('Carregar medidas'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: medidasAsync.when(
+                  data: (list) {
+                    if (list.isEmpty) {
+                      return const Center(
+                        child: Text(
+                            'Nenhuma medida encontrada para a chave informada.'),
+                      );
+                    }
+                    return ListView.separated(
+                      itemCount: list.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 8),
+                      itemBuilder: (context, index) {
+                        final item = list[index];
+                        return _MeasurementTile(
+                          item: item,
+                          onSelect: (status) => ref
+                              .read(medidasOperadorControllerProvider.notifier)
+                              .setStatus(index, status),
+                        );
+                      },
+                    );
+                  },
+                  loading: () => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                  error: (e, _) => Center(
+                    child: Text('Erro ao carregar:\n${e.toString()}'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MeasurementTile extends StatelessWidget {
+  final MedidaItem item;
+  final void Function(StatusMedida) onSelect;
+
+  const _MeasurementTile({
+    required this.item,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final styleLabel = Theme.of(context).textTheme.titleMedium;
+    final styleSpec = Theme.of(context).textTheme.bodyMedium;
+
+    String subtitulo = item.faixaTexto;
+    if (subtitulo.isEmpty && (item.minimo != null || item.maximo != null)) {
+      final minStr = item.minimo?.toStringAsFixed(2) ?? '';
+      final maxStr = item.maximo?.toStringAsFixed(2) ?? '';
+      final uni = (item.unidade ?? '').isNotEmpty ? ' ${item.unidade}' : '';
+      if (minStr.isNotEmpty && maxStr.isNotEmpty) {
+        subtitulo = '$minStr – $maxStr$uni';
+      } else if (minStr.isNotEmpty) {
+        subtitulo = '≥ $minStr$uni';
+      } else if (maxStr.isNotEmpty) {
+        subtitulo = '≤ $maxStr$uni';
+      }
+    }
+
+    return Card(
+      elevation: 0.5,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(item.titulo.isEmpty ? '(sem título)' : item.titulo,
+                style: styleLabel),
+            const SizedBox(height: 4),
+            Text(subtitulo.isEmpty ? '(sem faixa)' : subtitulo,
+                style: styleSpec),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                ChoiceChip(
+                  label: const Text('OK'),
+                  selected: item.status == StatusMedida.ok,
+                  onSelected: (_) => onSelect(StatusMedida.ok),
+                ),
+                ChoiceChip(
+                  label: const Text('Alerta'),
+                  selected: item.status == StatusMedida.alerta,
+                  onSelected: (_) => onSelect(StatusMedida.alerta),
+                ),
+                ChoiceChip(
+                  label: const Text('Reprovada'),
+                  selected: item.status == StatusMedida.reprovada,
+                  onSelected: (_) => onSelect(StatusMedida.reprovada),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add main menu with areas for Preparador, Operador and Supervisão
- Introduce operator area reusing measurement workflow with dedicated API endpoints
- Extend Flask server to serve operator spreadsheet and expose `/operador/medidas`

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `python -m py_compile server/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a461d398f88331a707f5a548d08663