### PR TITLE
Move PreparacaoPage to presentation and fix imports

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../preparacao/presentation/widgets/preparacao_page.dart';
+import '../preparacao/presentation/preparacao_page.dart';
 import '../operador/presentation/operador_page.dart';
 
 class MainMenuPage extends StatelessWidget {

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // IMPORTS ALINHADOS COM A ESTRUTURA QUE TE PASSEI
-import '../../data/models.dart';
-import '../../data/repository_provider.dart';
+import '../data/models.dart';
+import '../data/repository_provider.dart';
 
 /// Provider do controller (Riverpod)
 final medidasControllerProvider = StateNotifierProvider.autoDispose<

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:relic_ttprod/app.dart';
-import 'package:relic_ttprod/features/preparacao/presentation/widgets/preparacao_page.dart';
+import 'package:relic_ttprod/features/preparacao/presentation/preparacao_page.dart';
 
 void main() {
   testWidgets('App builds home page', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- move PreparacaoPage from presentation/widgets to presentation root
- update imports to new location

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a467e127bc8331a86aad0b847efebe