### PR TITLE
Fix Supervisao page const usage

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -58,9 +58,9 @@ class _SupervisaoPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: AppBar(title: Text('Supervisão')),
-      body: Center(child: Text('Em desenvolvimento')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Supervisão')),
+      body: const Center(child: Text('Em desenvolvimento')),
     );
   }
 }


### PR DESCRIPTION
## Summary
- fix Supervisao page to use a non-const `Scaffold` and keep constant text widgets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4732db7d88331bf6bb240c38d11e1