### PR TITLE
Use package imports for main menu

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../preparacao/presentation/preparacao_page.dart';
-import '../operador/presentation/operador_page.dart';
+import 'package:relic_ttprod/features/preparacao/presentation/preparacao_page.dart';
+import 'package:relic_ttprod/features/operador/presentation/operador_page.dart';
 
 class MainMenuPage extends StatelessWidget {
   const MainMenuPage({super.key});


### PR DESCRIPTION
## Summary
- avoid missing file errors by importing Preparacao and Operador pages via package paths

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a474afb0308331981ff14a3e34bc29