### PR TITLE
Enable CORS and add result endpoints for Python server

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -3,12 +3,10 @@ from flask import Flask, request, jsonify
 from openpyxl import load_workbook
 from pathlib import Path
 import re
-
-# Se precisar de CORS, descomenta as 2 linhas abaixo:
-# from flask_cors import CORS
+from flask_cors import CORS
 
 app = Flask(__name__)
-# CORS(app)
+CORS(app)
 
 # ========================= CONFIG =========================
 PLANILHA_PREPARADOR_PATH = (
@@ -182,6 +180,23 @@ def get_medidas_operador():
         return jsonify(_extrair_medidas_quartetos(row_vals))
     except Exception as e:
         return jsonify({"error": f"Falha ao ler planilha do OPERADOR: {e}"}), 500
+
+
+@app.post("/resultado")
+def post_resultado_preparador():
+    """Recebe o resultado de medições do preparador.
+
+    Neste protótipo os dados são apenas retornados como confirmação.
+    """
+    data = request.get_json(silent=True) or {}
+    return jsonify({"status": "ok", "received": data})
+
+
+@app.post("/operador/resultado")
+def post_resultado_operador():
+    """Recebe o resultado de medições do operador."""
+    data = request.get_json(silent=True) or {}
+    return jsonify({"status": "ok", "received": data})
 
 # ========================= MAIN ==========================
 if __name__ == "__main__":

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,2 +1,3 @@
 flask==3.0.3
 openpyxl==3.1.5
+flask-cors==4.0.0


### PR DESCRIPTION
## Summary
- allow cross-origin requests in Python Flask server
- add placeholder endpoints to receive preparador and operador results
- include flask-cors dependency

## Testing
- `pip install -r server/requirements.txt` *(fails: Cannot connect to proxy / no matching distribution)*
- `python -m py_compile server/app.py`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4915b44d883318442a6b30a5bcda8