### PR TITLE
Handle leading zeros in query parameters

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -28,7 +28,8 @@ def _norm(text):
     return (str(text or "")).strip()
 
 def _only_digits(text):
-    return re.sub(r"\D+", "", str(text or ""))
+    s = re.sub(r"\D+", "", str(text or ""))
+    return str(int(s)) if s else ""
 
 def _keys_match(cell_value: str, part: str, op: str) -> bool:
     s = _norm(cell_value)


### PR DESCRIPTION
## Summary
- normalize numeric parameters to compare without leading zeros

## Testing
- `python -m py_compile server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a494bed6e483318040935bdcc04ae9