### PR TITLE
fix: adjust API paths for preparador

### DIFF
--- a/lib/features/preparacao/data/medidas_repository_factory.dart
+++ b/lib/features/preparacao/data/medidas_repository_factory.dart
@@ -18,12 +18,18 @@ class MedidasRepositoryFactory {
   static MedidasRepository create({
     required bool useApi,
     String? baseUrlOverride,
+    String? medidasPath,
+    String? resultadoPath,
     String? assetPath,
     String? planilhaPath,
     String? aba,
   }) {
     if (useApi) {
-      return ApiMedidasRepository(overrideBaseUrl: baseUrlOverride);
+      return ApiMedidasRepository(
+        overrideBaseUrl: baseUrlOverride,
+        medidasPath: medidasPath ?? '/medidas',
+        resultadoPath: resultadoPath ?? '/resultado',
+      );
     }
 
     if (planilhaPath != null) {

--- a/lib/features/preparacao/data/repository_provider.dart
+++ b/lib/features/preparacao/data/repository_provider.dart
@@ -4,5 +4,9 @@ import 'medidas_repository.dart';
 import 'medidas_repository_factory.dart';
 
 final medidasRepositoryProvider = Provider<MedidasRepository>((ref) {
-  return MedidasRepositoryFactory.create(useApi: true);
+  return MedidasRepositoryFactory.create(
+    useApi: true,
+    medidasPath: '/preparador/medidas',
+    resultadoPath: '/preparador/resultado',
+  );
 });


### PR DESCRIPTION
## Summary
- route preparacao requests to `/preparador/medidas`
- allow MedidasRepositoryFactory to customize API endpoints

## Testing
- `dart format lib/features/preparacao/data/medidas_repository_factory.dart lib/features/preparacao/data/repository_provider.dart` (fail: command not found)
- `flutter test` (fail: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4a41fb9948331907b8e4f1efa185d