### PR TITLE
fix: adjust API paths for preparador and operador

### DIFF
--- a/lib/features/operador/data/repository_provider.dart
+++ b/lib/features/operador/data/repository_provider.dart
@@ -1,10 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../preparacao/data/medidas_repository.dart';
-import '../../preparacao/data/api_medidas_repository.dart';
+import '../../preparacao/data/medidas_repository_factory.dart';
 
 final operadorRepositoryProvider = Provider<MedidasRepository>((ref) {
-  return ApiMedidasRepository(
+  return MedidasRepositoryFactory.create(
+    useApi: true,
     medidasPath: '/operador/medidas',
     resultadoPath: '/operador/resultado',
   );

--- a/lib/features/preparacao/data/medidas_repository_factory.dart
+++ b/lib/features/preparacao/data/medidas_repository_factory.dart
@@ -18,12 +18,18 @@ class MedidasRepositoryFactory {
   static MedidasRepository create({
     required bool useApi,
     String? baseUrlOverride,
+    String? medidasPath,
+    String? resultadoPath,
     String? assetPath,
     String? planilhaPath,
     String? aba,
   }) {
     if (useApi) {
-      return ApiMedidasRepository(overrideBaseUrl: baseUrlOverride);
+      return ApiMedidasRepository(
+        overrideBaseUrl: baseUrlOverride,
+        medidasPath: medidasPath ?? '/medidas',
+        resultadoPath: resultadoPath ?? '/resultado',
+      );
     }
 
     if (planilhaPath != null) {

--- a/lib/features/preparacao/data/repository_provider.dart
+++ b/lib/features/preparacao/data/repository_provider.dart
@@ -4,5 +4,9 @@ import 'medidas_repository.dart';
 import 'medidas_repository_factory.dart';
 
 final medidasRepositoryProvider = Provider<MedidasRepository>((ref) {
-  return MedidasRepositoryFactory.create(useApi: true);
+  return MedidasRepositoryFactory.create(
+    useApi: true,
+    medidasPath: '/preparador/medidas',
+    resultadoPath: '/preparador/resultado',
+  );
 });


### PR DESCRIPTION
## Summary
- route preparacao requests to `/preparador/medidas`
- allow MedidasRepositoryFactory to customize API endpoints
- route operador requests through factory with `/operador/medidas`

## Testing
- `dart format lib/features/operador/data/repository_provider.dart` (fail: command not found)
- `flutter test` (fail: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68a4a41fb9948331907b8e4f1efa185d