### PR TITLE
Fix field names for measures returned by Flask API

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -95,8 +95,8 @@ def _extrair_medidas_pares(row_vals):
             break
         mn, mx, uni = _parse_range(faixa)
         medidas.append({
-            "etiqueta": etiqueta or "",
-            "faixa": faixa or "",
+            "titulo": etiqueta or "",
+            "faixaTexto": faixa or "",
             "min": mn,
             "max": mx,
             "unidade": uni,
@@ -116,8 +116,8 @@ def _extrair_medidas_quartetos(row_vals):
             break
         mn, mx, uni = _parse_range(faixa)
         medidas.append({
-            "tipo": tipo or "",
-            "faixa": faixa or "",
+            "titulo": tipo or "",
+            "faixaTexto": faixa or "",
             "min": mn,
             "max": mx,
             "unidade": uni,


### PR DESCRIPTION
## Summary
- return `titulo` and `faixaTexto` from Flask for preparador and operador measure endpoints

## Testing
- `python -m py_compile server/app.py`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a9346cc88331afcb8da759f62ae7