### PR TITLE
Adiciona periodicidade e instrumento nas medidas do operador

### DIFF
--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -41,7 +41,10 @@ class MedidasOperadorController
       maximo: current[index].maximo,
       unidade: current[index].unidade,
       status: status,
+      medicao: current[index].medicao,
       observacao: current[index].observacao,
+      periodicidade: current[index].periodicidade,
+      instrumento: current[index].instrumento,
     );
     state = AsyncValue.data(current);
   }
@@ -243,6 +246,14 @@ class _MeasurementTile extends StatelessWidget {
             const SizedBox(height: 4),
             Text(subtitulo.isEmpty ? '(sem faixa)' : subtitulo,
                 style: styleSpec),
+            if ((item.periodicidade ?? '').isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text('Periodicidade: ${item.periodicidade}', style: styleSpec),
+            ],
+            if ((item.instrumento ?? '').isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text('Instrumento: ${item.instrumento}', style: styleSpec),
+            ],
             const SizedBox(height: 8),
             Wrap(
               spacing: 8,

--- a/lib/features/preparacao/data/local_excel_repository.dart
+++ b/lib/features/preparacao/data/local_excel_repository.dart
@@ -74,6 +74,8 @@ class LocalExcelRepository implements MedidasRepository {
           status: statusFromString(map['status']?.toString()),
           medicao: map['medicao']?.toString(),
           observacao: map['observacao']?.toString(),
+          periodicidade: map['periodicidade']?.toString(),
+          instrumento: map['instrumento']?.toString(),
         );
       }).toList();
     }

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -44,6 +44,8 @@ class MedidaItem {
   final StatusMedida status;
   final String? medicao;
   final String? observacao;
+  final String? periodicidade;
+  final String? instrumento;
 
   MedidaItem({
     required this.titulo,
@@ -54,6 +56,8 @@ class MedidaItem {
     this.status = StatusMedida.pendente,
     this.medicao,
     this.observacao,
+    this.periodicidade,
+    this.instrumento,
   });
 
   factory MedidaItem.fromMap(Map<String, dynamic> map) {
@@ -73,6 +77,8 @@ class MedidaItem {
       status: statusFromString(map['status']?.toString()),
       medicao: map['medicao']?.toString(),
       observacao: map['observacao']?.toString(),
+      periodicidade: map['periodicidade']?.toString(),
+      instrumento: map['instrumento']?.toString(),
     );
   }
 
@@ -85,6 +91,8 @@ class MedidaItem {
     'status': statusToString(status),
     'medicao': medicao,
     'observacao': observacao,
+    'periodicidade': periodicidade,
+    'instrumento': instrumento,
   };
 }
 

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -41,7 +41,10 @@ class MedidasController extends StateNotifier<AsyncValue<List<MedidaItem>>> {
       maximo: current[index].maximo,
       unidade: current[index].unidade,
       status: status,
+      medicao: current[index].medicao,
       observacao: current[index].observacao,
+      periodicidade: current[index].periodicidade,
+      instrumento: current[index].instrumento,
     );
     state = AsyncValue.data(current);
   }


### PR DESCRIPTION
## Summary
- inclui campos de periodicidade e instrumento em `MedidaItem`
- preserva esses dados ao alterar status das medidas
- exibe periodicidade e instrumento na tela do operador
- ajusta repositório local para ler os novos campos

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b200b7e48331935e4c33636c0931