### PR TITLE
fix: resolve analyzer warnings

### DIFF
--- a/lib/features/preparacao/data/api_medidas_repository.dart
+++ b/lib/features/preparacao/data/api_medidas_repository.dart
@@ -38,7 +38,7 @@ class ApiMedidasRepository implements MedidasRepository {
       port: root.hasPort ? root.port : null,
       path: normalizedPath, // <- nunca prefixa com caminho do baseUrl
       queryParameters:
-      query?.map((k, v) => MapEntry(k, v == null ? null : v.toString())),
+      query?.map((k, v) => MapEntry(k, v?.toString())),
     );
   }
 

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -25,7 +25,6 @@ String statusToString(StatusMedida s) {
     case StatusMedida.reprovada:
       return 'reprovada';
     case StatusMedida.pendente:
-    default:
       return 'pendente';
   }
 }
@@ -61,7 +60,7 @@ class MedidaItem {
   });
 
   factory MedidaItem.fromMap(Map<String, dynamic> map) {
-    double? _toDouble(v) {
+    double? parseToDouble(v) {
       if (v == null) return null;
       if (v is num) return v.toDouble();
       final s = v.toString().replaceAll(',', '.').trim();
@@ -71,8 +70,8 @@ class MedidaItem {
     return MedidaItem(
       titulo: (map['titulo'] ?? '').toString(),
       faixaTexto: (map['faixaTexto'] ?? map['faixa_texto'] ?? '').toString(),
-      minimo: _toDouble(map['minimo'] ?? map['min']),
-      maximo: _toDouble(map['maximo'] ?? map['max']),
+      minimo: parseToDouble(map['minimo'] ?? map['min']),
+      maximo: parseToDouble(map['maximo'] ?? map['max']),
       unidade: map['unidade']?.toString(),
       status: statusFromString(map['status']?.toString()),
       medicao: map['medicao']?.toString(),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,7 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
## Summary
- remove unreachable default in StatusMedida switch
- use null-aware operator when mapping query params
- drop unused material import in widget test

## Testing
- `dart format lib/features/preparacao/data/models.dart lib/features/preparacao/data/api_medidas_repository.dart test/widget_test.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a75cf9673c8331ad27a8e09b0af5dd