### PR TITLE
feat: track over/under measurement status

### DIFF
--- a/lib/features/preparacao/data/api_medidas_repository.dart
+++ b/lib/features/preparacao/data/api_medidas_repository.dart
@@ -38,7 +38,7 @@ class ApiMedidasRepository implements MedidasRepository {
       port: root.hasPort ? root.port : null,
       path: normalizedPath, // <- nunca prefixa com caminho do baseUrl
       queryParameters:
-      query?.map((k, v) => MapEntry(k, v == null ? null : v.toString())),
+      query?.map((k, v) => MapEntry(k, v?.toString())),
     );
   }
 

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -1,7 +1,7 @@
 // lib/features/preparacao/data/models.dart
 import 'dart:convert';
 
-enum StatusMedida { ok, alerta, reprovada, pendente }
+enum StatusMedida { ok, alerta, reprovadaAcima, reprovadaAbaixo, pendente }
 
 StatusMedida statusFromString(String? s) {
   switch (s?.toLowerCase()) {
@@ -9,8 +9,13 @@ StatusMedida statusFromString(String? s) {
       return StatusMedida.ok;
     case 'alerta':
       return StatusMedida.alerta;
+    case 'reprovada_acima':
+    case 'acima':
     case 'reprovada':
-      return StatusMedida.reprovada;
+      return StatusMedida.reprovadaAcima;
+    case 'reprovada_abaixo':
+    case 'abaixo':
+      return StatusMedida.reprovadaAbaixo;
     default:
       return StatusMedida.pendente;
   }
@@ -22,10 +27,11 @@ String statusToString(StatusMedida s) {
       return 'ok';
     case StatusMedida.alerta:
       return 'alerta';
-    case StatusMedida.reprovada:
-      return 'reprovada';
+    case StatusMedida.reprovadaAcima:
+      return 'reprovada_acima';
+    case StatusMedida.reprovadaAbaixo:
+      return 'reprovada_abaixo';
     case StatusMedida.pendente:
-    default:
       return 'pendente';
   }
 }
@@ -61,7 +67,7 @@ class MedidaItem {
   });
 
   factory MedidaItem.fromMap(Map<String, dynamic> map) {
-    double? _toDouble(v) {
+    double? parseToDouble(v) {
       if (v == null) return null;
       if (v is num) return v.toDouble();
       final s = v.toString().replaceAll(',', '.').trim();
@@ -71,8 +77,8 @@ class MedidaItem {
     return MedidaItem(
       titulo: (map['titulo'] ?? '').toString(),
       faixaTexto: (map['faixaTexto'] ?? map['faixa_texto'] ?? '').toString(),
-      minimo: _toDouble(map['minimo'] ?? map['min']),
-      maximo: _toDouble(map['maximo'] ?? map['max']),
+      minimo: parseToDouble(map['minimo'] ?? map['min']),
+      maximo: parseToDouble(map['maximo'] ?? map['max']),
       unidade: map['unidade']?.toString(),
       status: statusFromString(map['status']?.toString()),
       medicao: map['medicao']?.toString(),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -47,9 +47,10 @@ class MedidasController extends StateNotifier<AsyncValue<List<MedidaItem>>> {
     if (valor != null) {
       final minimo = item.minimo;
       final maximo = item.maximo;
-      if ((minimo != null && valor < minimo) ||
-          (maximo != null && valor > maximo)) {
-        status = StatusMedida.reprovada;
+      if (minimo != null && valor < minimo) {
+        status = StatusMedida.reprovadaAbaixo;
+      } else if (maximo != null && valor > maximo) {
+        status = StatusMedida.reprovadaAcima;
       } else {
         status = StatusMedida.ok;
       }
@@ -303,12 +304,32 @@ class _MeasurementTile extends StatelessWidget {
                 filled: true,
                 fillColor: item.status == StatusMedida.ok
                     ? Colors.green.shade100
-                    : item.status == StatusMedida.reprovada
+                    : (item.status == StatusMedida.reprovadaAbaixo ||
+                            item.status == StatusMedida.reprovadaAcima)
                         ? Theme.of(context).colorScheme.errorContainer
                         : null,
               ),
               onChanged: onChanged,
             ),
+            const SizedBox(height: 8),
+            if (item.status != StatusMedida.pendente)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Chip(
+                  label: Text(
+                    item.status == StatusMedida.ok
+                        ? 'OK'
+                        : item.status == StatusMedida.reprovadaAcima
+                            ? 'Reprovada acima'
+                            : item.status == StatusMedida.reprovadaAbaixo
+                                ? 'Reprovada abaixo'
+                                : 'Alerta',
+                  ),
+                  backgroundColor: item.status == StatusMedida.ok
+                      ? Colors.green.shade100
+                      : Theme.of(context).colorScheme.errorContainer,
+                ),
+              ),
           ],
         ),
       ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,7 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
## Summary
- compute measurement status against min/max bounds
- show a read-only chip on the preparador screen indicating OK/over/under tolerance
- revert operador screen to its original status options

## Testing
- `dart format lib/features/preparacao/presentation/preparacao_page.dart lib/features/operador/presentation/operador_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a75cf9673c8331ad27a8e09b0af5dd